### PR TITLE
v0.9.18: add decodeHeaderLong() for M-Bus header decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-Fix conditional check for VIFs in case of timestamps
+## [0.9.18] - 2026-04-23
+
+### Added
+
+- New `decodeHeaderLong()` method: decodes M-Bus Long Frame header (ID, manufacturer, medium, status byte, version, access counter, signature) into a JSON object
+- Example updated to demonstrate header decoding
 
 ## [0.9.17] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ if (payload.decodeHeaderLong(mbus_data, packet_size, headerObj)) {
 }
 ```
 
-Example JSON output:
+Example JSON output (from a Cold water meter):
 
 ```
 {
@@ -138,20 +138,20 @@ Example JSON output:
   "c_field": 8,
   "a_field": 20,
   "ci_field": 114,
-  "id": "24337907",
-  "manufacturer": "NWM",
+  "id": "29079172",
+  "manufacturer": "WZG",
   "version": 3,
-  "medium": "Heat (Mass)",
-  "medium_code": 13,
-  "access_counter": 2,
-  "status": 198,
+  "medium_code": 22,
+  "medium": "Cold water",
+  "access_counter": 194,
+  "status": 0,
   "status_details": {
     "battery_low": false,
     "permanent_error": false,
-    "temporary_error": true,
-    "app_status": "any_error"
+    "temporary_error": false,
+    "app_status": "no_error"
   },
-  "signature": 14115
+  "signature": 0
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,83 @@ There are more records available but you have to delete the out comment in the l
 * **["value_raw"]** contains the raw value
 
 
+### Method: `decodeHeaderLong`
+
+Decodes the header of an M-Bus Long Frame telegram into a JsonObject (requires ArduinoJson library). Returns `true` on success, `false` on error.
+
+```c
+bool decodeHeaderLong(const uint8_t* buffer, size_t length, JsonObject& json);
+```
+
+- `const uint8_t* buffer`: Pointer to the raw M-Bus telegram (complete frame including start/stop bytes)
+- `size_t length`: Total length of the telegram
+- `JsonObject& json`: ArduinoJson object where the decoded header fields are written
+
+Usage example:
+```c
+MBusinoLib payload(254);
+
+StaticJsonDocument<512> headerDoc;
+JsonObject headerObj = headerDoc.to<JsonObject>();
+
+int packet_size = mbus_data[1] + 6;
+
+if (payload.decodeHeaderLong(mbus_data, packet_size, headerObj)) {
+    const char* meterId = headerObj["id"].as<const char*>();
+    const char* manufacturer = headerObj["manufacturer"].as<const char*>();
+    const char* medium = headerObj["medium"].as<const char*>();
+    int statusCode = headerObj["status"].as<int>();
+    int version = headerObj["version"].as<int>();
+    int accessCounter = headerObj["access_counter"].as<int>();
+
+    // Status details
+    bool battLow = headerObj["status_details"]["battery_low"].as<bool>();
+    bool tempErr = headerObj["status_details"]["temporary_error"].as<bool>();
+    bool permErr = headerObj["status_details"]["permanent_error"].as<bool>();
+}
+```
+
+Example JSON output:
+
+```
+{
+  "len": 196,
+  "c_field": 8,
+  "a_field": 20,
+  "ci_field": 114,
+  "id": "24337907",
+  "manufacturer": "NWM",
+  "version": 3,
+  "medium": "Heat (Mass)",
+  "medium_code": 13,
+  "access_counter": 2,
+  "status": 198,
+  "status_details": {
+    "battery_low": false,
+    "permanent_error": false,
+    "temporary_error": true,
+    "app_status": "any_error"
+  },
+  "signature": 14115
+}
+```
+
+### possible header fields
+
+* **["len"]** telegram length field
+* **["c_field"]** control field
+* **["a_field"]** address field
+* **["ci_field"]** control information field (0x72 or 0x76 = variable data with header)
+* **["id"]** meter identification number as HEX string
+* **["manufacturer"]** 3-letter manufacturer code
+* **["version"]** meter version/revision number
+* **["medium"]** medium name as text (e.g. "Electricity", "Gas", "Water")
+* **["medium_code"]** medium code as integer
+* **["access_counter"]** transmission counter
+* **["status"]** status byte as integer
+* **["status_details"]** nested object with decoded status bits: `battery_low`, `permanent_error`, `temporary_error`, `app_status`
+* **["signature"]** signature field
+
 ### Method: `getError`
 
 Returns the last error ID, once returned the error is reset to OK. Possible error values are:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MBusinoLib - an Arduino M-Bus Decoder Library
 
-[![version](https://img.shields.io/badge/version-0.9.17-brightgreen.svg)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-0.9.18-brightgreen.svg)](CHANGELOG.md)
 [![license](https://img.shields.io/badge/license-GPL--3.0-orange.svg)](LICENSE)
 
 

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/Zeppelin500/MBusinoLib.git"
     },
-    "version": "0.9.17",
+    "version": "0.9.18",
     "license": "GPL-3.0",
     "frameworks": "arduino",
     "platforms": ["atmelavr", "atmelsam", "espressif32" ,"espressif8266"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MBusinoLib
-version=0.9.17
+version=0.9.18
 author=Zeppelin500 <mbusinolib@gmail.com>
 maintainer=Zeppelin500 <mbusinolib@gmail.com>
 sentence=an Arduino M-Bus decoder Library


### PR DESCRIPTION
## Changes\n\n- New  method: decodes M-Bus Long Frame header (ID, manufacturer, medium, status byte, version, access counter, signature) into a JSON object\n- Updated example to demonstrate header decoding\n- README documentation for the new method\n- Version bumped to 0.9.18