### PR TITLE
v0.9.19: rename decode→decodeRecords, decodeHeaderLong→decodeHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.19] - 2026-04-25
+
+### Changed
+
+- Renamed `decode()` to `decodeRecords()` for clarity (old name kept as deprecated wrapper)
+- Renamed `decodeHeaderLong()` to `decodeHeader()` ("Long" was redundant)
+
 ## [0.9.18] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MBusinoLib - an Arduino M-Bus Decoder Library
 
-[![version](https://img.shields.io/badge/version-0.9.18-brightgreen.svg)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-0.9.19-brightgreen.svg)](CHANGELOG.md)
 [![license](https://img.shields.io/badge/license-GPL--3.0-orange.svg)](LICENSE)
 
 
@@ -38,17 +38,17 @@ MBusinoLib payload(uint8_t size);
 
 ## Decoding
 
-### Method: `decode`
+### Method: `decodeRecords`
 
 Decodes payload of a whole M-Bus telegram as byte array into a JsonArray (requires ArduinoJson library). The result is an array of objects. The method call returns the number of decoded fields or 0 if error.
 
 ```c
-uint8_t decode(uint8_t *buffer, uint8_t size, JsonArray& root);
+uint8_t decodeRecords(uint8_t *buffer, uint8_t size, JsonArray& root);
 ```
 
 same line from the example
 ```c
-uint8_t fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
+uint8_t fields = payload.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
 ```
 
 Example JSON output:
@@ -94,12 +94,12 @@ There are more records available but you have to delete the out comment in the l
 * **["value_raw"]** contains the raw value
 
 
-### Method: `decodeHeaderLong`
+### Method: `decodeHeader`
 
 Decodes the header of an M-Bus Long Frame telegram into a JsonObject (requires ArduinoJson library). Returns `true` on success, `false` on error.
 
 ```c
-bool decodeHeaderLong(const uint8_t* buffer, size_t length, JsonObject& json);
+bool decodeHeader(const uint8_t* buffer, size_t length, JsonObject& json);
 ```
 
 - `const uint8_t* buffer`: Pointer to the raw M-Bus telegram (complete frame including start/stop bytes)
@@ -115,7 +115,7 @@ JsonObject headerObj = headerDoc.to<JsonObject>();
 
 int packet_size = mbus_data[1] + 6;
 
-if (payload.decodeHeaderLong(mbus_data, packet_size, headerObj)) {
+if (payload.decodeHeader(mbus_data, packet_size, headerObj)) {
     const char* meterId = headerObj["id"].as<const char*>();
     const char* manufacturer = headerObj["manufacturer"].as<const char*>();
     const char* medium = headerObj["medium"].as<const char*>();

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Thanks to **HWHardsoft** and **TrystanLea** for the M-Bus communication for MBus
 
 ### Class: `MBusinoLib`
 
-Include and instantiate the MBusinoLib class. The constructor takes the size of the allocated buffer.
+Include and instantiate the MBusinoLib class:
 
 ```c
 #include <MBusinoLib.h>

--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ Include and instantiate the MBusinoLib class. The constructor takes the size of 
 ```c
 #include <MBusinoLib.h>
 
-MBusinoLib payload(uint8_t size);
+MBusinoLib decode;
 ```
-
-- `uint8_t size`: The maximum payload size to send, e.g. `254`
 
 ## Decoding
 
@@ -48,7 +46,7 @@ uint8_t decodeRecords(uint8_t *buffer, uint8_t size, JsonArray& root);
 
 same line from the example
 ```c
-uint8_t fields = payload.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
+uint8_t fields = decode.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
 ```
 
 Example JSON output:
@@ -108,14 +106,14 @@ bool decodeHeader(const uint8_t* buffer, size_t length, JsonObject& json);
 
 Usage example:
 ```c
-MBusinoLib payload(254);
+MBusinoLib decode;
 
 StaticJsonDocument<512> headerDoc;
 JsonObject headerObj = headerDoc.to<JsonObject>();
 
 int packet_size = mbus_data[1] + 6;
 
-if (payload.decodeHeader(mbus_data, packet_size, headerObj)) {
+if (decode.decodeHeader(mbus_data, packet_size, headerObj)) {
     const char* meterId = headerObj["id"].as<const char*>();
     const char* manufacturer = headerObj["manufacturer"].as<const char*>();
     const char* medium = headerObj["medium"].as<const char*>();

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,11 +18,12 @@ getBuffer KEYWORD2
 copy KEYWORD2
 getError KEYWORD2
 
-addRaw KEYWORD2
-addField KEYWORD2
-
-decode KEYWORD2
+decodeRecords KEYWORD2
+decodeHeader KEYWORD2
+getCodeName KEYWORD2
 getCodeUnits KEYWORD2
+getDeviceClass KEYWORD2
+getStateClass KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/Zeppelin500/MBusinoLib.git"
     },
-    "version": "0.9.18",
+    "version": "0.9.19",
     "license": "GPL-3.0",
     "frameworks": "arduino",
     "platforms": ["atmelavr", "atmelsam", "espressif32" ,"espressif8266"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MBusinoLib
-version=0.9.18
+version=0.9.19
 author=Zeppelin500 <mbusinolib@gmail.com>
 maintainer=Zeppelin500 <mbusinolib@gmail.com>
 sentence=an Arduino M-Bus decoder Library


### PR DESCRIPTION
## Changes
- Renamed `decode()` to `decodeRecords()` for clarity (old name kept as deprecated wrapper)
- Renamed `decodeHeaderLong()` to `decodeHeader()` ("Long" was redundant)
- Updated README with new function names and removed outdated constructor description
- Updated keywords.txt (removed stale methods, added missing ones)
- Updated library.json version to 0.9.19