### PR TITLE
refactor: rename a_field to address in decodeHeader()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.20] - 2026-04-28
+
+### Changed
+
+- Renamed `a_field` to `address` in `decodeHeader()` JSON output
+
 ## [0.9.19] - 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MBusinoLib - an Arduino M-Bus Decoder Library
 
-[![version](https://img.shields.io/badge/version-0.9.19-brightgreen.svg)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-0.9.20-brightgreen.svg)](CHANGELOG.md)
 [![license](https://img.shields.io/badge/license-GPL--3.0-orange.svg)](LICENSE)
 
 

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/Zeppelin500/MBusinoLib.git"
     },
-    "version": "0.9.19",
+    "version": "0.9.20",
     "license": "GPL-3.0",
     "frameworks": "arduino",
     "platforms": ["atmelavr", "atmelsam", "espressif32" ,"espressif8266"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MBusinoLib
-version=0.9.19
+version=0.9.20
 author=Zeppelin500 <mbusinolib@gmail.com>
 maintainer=Zeppelin500 <mbusinolib@gmail.com>
 sentence=an Arduino M-Bus decoder Library

--- a/src/MBusinoLib.cpp
+++ b/src/MBusinoLib.cpp
@@ -1520,7 +1520,7 @@ bool MBusinoLib::decodeHeader(const uint8_t* buffer, size_t length, JsonObject& 
     // Extract basic header fields
     json["len"] = buffer[1];
     json["c_field"] = buffer[4];
-    json["a_field"] = buffer[5];
+    json["address"] = buffer[5];
     json["ci_field"] = buffer[6];
 
     // Check if the CI field indicates a variable data structure (0x72 or 0x76)

--- a/src/MBusinoLib.cpp
+++ b/src/MBusinoLib.cpp
@@ -1466,14 +1466,14 @@ const char * MBusinoLib::getStateClass(uint8_t code) {
 // ----------------------------------------------------------------------------
 
 const char * MBusinoLib::getHeaderDeviceClass(const char * fieldName) {
-  if (strcmp(fieldName, "battery_low") == 0) return "battery";
-  // All other header fields have no device_class in HA
+  // battery_low is boolean, not percentage — 'battery' device_class doesn't fit
+  // All header fields currently have no device_class in HA
   return "";
 }
 
 const char * MBusinoLib::getHeaderStateClass(const char * fieldName) {
-  if (strcmp(fieldName, "access_counter") == 0) return "total_increasing";
-  // All other header fields have no state_class in HA
+  // access_counter is 1 byte (0-255), wraps around — 'total_increasing' doesn't fit
+  // All header fields currently have no state_class in HA
   return "";
 }
 

--- a/src/MBusinoLib.cpp
+++ b/src/MBusinoLib.cpp
@@ -1465,6 +1465,20 @@ const char * MBusinoLib::getStateClass(uint8_t code) {
 
 // ----------------------------------------------------------------------------
 
+const char * MBusinoLib::getHeaderDeviceClass(const char * fieldName) {
+  if (strcmp(fieldName, "battery_low") == 0) return "battery";
+  // All other header fields have no device_class in HA
+  return "";
+}
+
+const char * MBusinoLib::getHeaderStateClass(const char * fieldName) {
+  if (strcmp(fieldName, "access_counter") == 0) return "total_increasing";
+  // All other header fields have no state_class in HA
+  return "";
+}
+
+// ----------------------------------------------------------------------------
+
 int16_t MBusinoLib::_findDefinition(uint32_t vif) {
   
   for (uint8_t i=0; i<MBUS_VIF_DEF_NUM; i++) {

--- a/src/MBusinoLib.cpp
+++ b/src/MBusinoLib.cpp
@@ -1465,20 +1465,6 @@ const char * MBusinoLib::getStateClass(uint8_t code) {
 
 // ----------------------------------------------------------------------------
 
-const char * MBusinoLib::getHeaderDeviceClass(const char * fieldName) {
-  // battery_low is boolean, not percentage — 'battery' device_class doesn't fit
-  // All header fields currently have no device_class in HA
-  return "";
-}
-
-const char * MBusinoLib::getHeaderStateClass(const char * fieldName) {
-  // access_counter is 1 byte (0-255), wraps around — 'total_increasing' doesn't fit
-  // All header fields currently have no state_class in HA
-  return "";
-}
-
-// ----------------------------------------------------------------------------
-
 int16_t MBusinoLib::_findDefinition(uint32_t vif) {
   
   for (uint8_t i=0; i<MBUS_VIF_DEF_NUM; i++) {

--- a/src/MBusinoLib.h
+++ b/src/MBusinoLib.h
@@ -383,8 +383,6 @@ public:
   const char * getCodeUnits(uint8_t code);
   const char * getDeviceClass(uint8_t code);
   const char * getStateClass(uint8_t code);
-  const char * getHeaderDeviceClass(const char * fieldName);
-  const char * getHeaderStateClass(const char * fieldName);
 
   bool decodeHeader(const uint8_t* buffer, size_t length, JsonObject& json);
 

--- a/src/MBusinoLib.h
+++ b/src/MBusinoLib.h
@@ -383,6 +383,8 @@ public:
   const char * getCodeUnits(uint8_t code);
   const char * getDeviceClass(uint8_t code);
   const char * getStateClass(uint8_t code);
+  const char * getHeaderDeviceClass(const char * fieldName);
+  const char * getHeaderStateClass(const char * fieldName);
 
   bool decodeHeader(const uint8_t* buffer, size_t length, JsonObject& json);
 


### PR DESCRIPTION
Renames the JSON key `a_field` to `address` in `decodeHeader()`. The field contains the M-Bus slave address, so `address` is more intuitive and matches the MQTT topic naming convention.